### PR TITLE
Update deploy-to-digital-ocean.md

### DIFF
--- a/laravel/deploy-to-digital-ocean.md
+++ b/laravel/deploy-to-digital-ocean.md
@@ -91,7 +91,7 @@ Given that, make the user `www-data` own the `storage` directory and everything 
 $ chown -R www-data storage
 ```
 
-And now do the same two steps for the `bootstrap/cache` directory:
+And now make the same change for the `bootstrap/cache` directory:
 ```xml
 $ chown -R www-data bootstrap/cache
 ```


### PR DESCRIPTION
I'm assuming the permission change was just the single step mentioned, so wording changed to omit "two". But if there is another step, that should be included.