### PR TITLE
Line 57: Error for ../bin/ not ../composer/

### DIFF
--- a/laravel/composer-mac.md
+++ b/laravel/composer-mac.md
@@ -54,7 +54,7 @@ Move into your `/usr/local/bin` directory. This is a common location to put comm
 $ sudo cd /usr/local/bin
 ```
 
-Note: On some versions of OSX the `/usr` directory does not exist by default. If you receive the error */usr/local/bin/composer: No such file or directory* then you must create the directory manually using this command
+Note: On some versions of OSX the `/usr` directory does not exist by default. If you receive the error */usr/local/bin: No such file or directory* then you must create the directory manually using this command
 ```bash
 sudo mkdir -p /usr/local/bin
 ```


### PR DESCRIPTION
At this point in the process there shouldn't be a composer directory; the error would be because the bin directory doesn't exist. I revised Line 57 to show the error path as /usr/local/bin instead of /usr/local/bin/composer.